### PR TITLE
Added Support for Jellyfin. Closes #11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,19 @@
 # MediaSage Environment Variables
 # Copy this file to .env and update with your actual values
 
-# Plex Server Configuration
+# Media server selection: "plex" or "jellyfin"
+# Auto-detected: if JELLYFIN_URL is set and PLEX_URL is not, defaults to "jellyfin"
+#MEDIA_SERVER=plex
+
+# Plex Server Configuration (use if MEDIA_SERVER=plex)
 PLEX_URL=http://your-plex-server:32400
 PLEX_TOKEN=your-plex-token
+
+# Jellyfin Server Configuration (use if MEDIA_SERVER=jellyfin)
+# API key: create in Jellyfin Dashboard > API Keys
+#JELLYFIN_URL=http://your-jellyfin-server:8096
+#JELLYFIN_TOKEN=your-jellyfin-api-key
+#JELLYFIN_MUSIC_LIBRARY=Music
 
 # LLM Provider (anthropic, openai, gemini, ollama, or custom)
 # Defaults to gemini if not set. Can also be configured in UI.

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,7 +7,7 @@ from typing import Any
 import yaml
 from dotenv import load_dotenv
 
-from backend.models import AppConfig, DefaultsConfig, LLMConfig, PlexConfig
+from backend.models import AppConfig, DefaultsConfig, JellyfinConfig, LLMConfig, PlexConfig
 
 # Load .env file (if it exists) - env vars take priority
 load_dotenv()
@@ -148,6 +148,7 @@ def load_config(config_path: Path | None = None) -> AppConfig:
 
     # Extract nested config sections
     plex_yaml = yaml_config.get("plex", {})
+    jellyfin_yaml = yaml_config.get("jellyfin", {})
     llm_yaml = yaml_config.get("llm", {})
     defaults_yaml = yaml_config.get("defaults", {})
 
@@ -196,6 +197,27 @@ def load_config(config_path: Path | None = None) -> AppConfig:
             "PLEX_MUSIC_LIBRARY", plex_yaml.get("music_library"), "Music"
         ),
     )
+
+    jellyfin_config = JellyfinConfig(
+        url=get_env_or_yaml("JELLYFIN_URL", jellyfin_yaml.get("url"), ""),
+        token=get_env_or_yaml("JELLYFIN_TOKEN", jellyfin_yaml.get("token"), ""),
+        music_library=get_env_or_yaml(
+            "JELLYFIN_MUSIC_LIBRARY", jellyfin_yaml.get("music_library"), "Music"
+        ),
+    )
+
+    # Determine media server: env var > yaml > auto-detect > default "plex"
+    media_server_yaml = yaml_config.get("media_server")
+    media_server_env = os.environ.get("MEDIA_SERVER")
+    if media_server_env:
+        media_server = media_server_env
+    elif media_server_yaml:
+        media_server = media_server_yaml
+    elif jellyfin_config.url and not plex_config.url:
+        # Auto-detect: Jellyfin URL set but not Plex
+        media_server = "jellyfin"
+    else:
+        media_server = "plex"
 
     # Get local provider settings
     ollama_url = get_env_or_yaml(
@@ -260,7 +282,9 @@ def load_config(config_path: Path | None = None) -> AppConfig:
     )
 
     return AppConfig(
+        media_server=media_server,
         plex=plex_config,
+        jellyfin=jellyfin_config,
         llm=llm_config,
         defaults=defaults_config,
     )
@@ -297,7 +321,12 @@ def update_config_values(updates: dict[str, Any]) -> AppConfig:
 
     # Create updated config by merging updates
     plex_updates = {}
+    jellyfin_updates = {}
     llm_updates = {}
+    top_level_updates = {}
+
+    if "media_server" in updates and updates["media_server"]:
+        top_level_updates["media_server"] = updates["media_server"]
 
     if "plex_url" in updates and updates["plex_url"]:
         plex_updates["url"] = updates["plex_url"]
@@ -305,6 +334,13 @@ def update_config_values(updates: dict[str, Any]) -> AppConfig:
         plex_updates["token"] = updates["plex_token"]
     if "music_library" in updates and updates["music_library"]:
         plex_updates["music_library"] = updates["music_library"]
+
+    if "jellyfin_url" in updates and updates["jellyfin_url"]:
+        jellyfin_updates["url"] = updates["jellyfin_url"]
+    if "jellyfin_token" in updates and updates["jellyfin_token"]:
+        jellyfin_updates["token"] = updates["jellyfin_token"]
+    if "jellyfin_music_library" in updates and updates["jellyfin_music_library"]:
+        jellyfin_updates["music_library"] = updates["jellyfin_music_library"]
 
     if "llm_provider" in updates and updates["llm_provider"]:
         new_provider = updates["llm_provider"]
@@ -347,18 +383,26 @@ def update_config_values(updates: dict[str, Any]) -> AppConfig:
 
     # Create new config with updates
     new_plex = _config.plex.model_copy(update=plex_updates)
+    new_jellyfin = _config.jellyfin.model_copy(update=jellyfin_updates)
     new_llm = _config.llm.model_copy(update=llm_updates)
+    new_media_server = top_level_updates.get("media_server", _config.media_server)
 
     _config = AppConfig(
+        media_server=new_media_server,
         plex=new_plex,
+        jellyfin=new_jellyfin,
         llm=new_llm,
         defaults=_config.defaults,
     )
 
     # Persist to user config file
     user_updates: dict[str, Any] = {}
+    if top_level_updates:
+        user_updates.update(top_level_updates)
     if plex_updates:
         user_updates["plex"] = plex_updates
+    if jellyfin_updates:
+        user_updates["jellyfin"] = jellyfin_updates
     if llm_updates:
         user_updates["llm"] = llm_updates
 
@@ -366,3 +410,19 @@ def update_config_values(updates: dict[str, Any]) -> AppConfig:
         save_user_config(user_updates)
 
     return _config
+
+
+def get_current_media_client():
+    """Get the media client for the currently configured media server.
+
+    Returns:
+        PlexClient or JellyfinClient based on config.media_server.
+        Returns None if the relevant server is not configured.
+    """
+    config = get_config()
+    if config.media_server == "jellyfin":
+        from backend.jellyfin_client import JellyfinClient, get_jellyfin_client
+        return get_jellyfin_client()
+    else:
+        from backend.plex_client import get_plex_client
+        return get_plex_client()

--- a/backend/generator.py
+++ b/backend/generator.py
@@ -7,7 +7,8 @@ from datetime import datetime
 
 from backend.llm_client import get_llm_client
 from backend.models import GenerateResponse, Track
-from backend.plex_client import PlexQueryError, get_plex_client
+from backend.plex_client import PlexQueryError
+from backend.config import get_current_media_client
 from backend import library_cache
 
 logger = logging.getLogger(__name__)
@@ -168,13 +169,13 @@ def generate_playlist_stream(
     try:
         logger.info("Starting playlist generation (streaming)")
         llm_client = get_llm_client()
-        plex_client = get_plex_client()
+        plex_client = get_current_media_client()
 
         if not llm_client:
             yield emit("error", {"message": "LLM client not initialized"})
             return
         if not plex_client:
-            yield emit("error", {"message": "Plex client not initialized"})
+            yield emit("error", {"message": "Media server not connected"})
             return
 
         has_filters = genres or decades or min_rating > 0

--- a/backend/jellyfin_client.py
+++ b/backend/jellyfin_client.py
@@ -1,0 +1,673 @@
+"""Jellyfin media server client using REST API via httpx."""
+
+import logging
+import random
+from typing import Any
+
+import httpx
+
+from backend.media_client import BaseMediaClient, is_live_track
+from backend.models import PlexPlaylistInfo, Track
+
+logger = logging.getLogger(__name__)
+
+# Singleton instance
+_jellyfin_client: "JellyfinClient | None" = None
+
+
+def _decade_to_years(decade: str) -> list[int]:
+    """Convert a decade string like '1980s' to a list of years [1980..1989]."""
+    decade = decade.strip().rstrip("s")
+    try:
+        start = int(decade)
+        return list(range(start, start + 10))
+    except ValueError:
+        return []
+
+
+class JellyfinClient(BaseMediaClient):
+    """Client for interacting with Jellyfin media server via REST API."""
+
+    def __init__(self, url: str, token: str, music_library: str = "Music"):
+        self.url = url.rstrip("/")
+        self.token = token
+        self.music_library_name = music_library
+
+        self._connected = False
+        self._error: str | None = None
+        self._user_id: str | None = None
+        self._library_id: str | None = None
+
+        self._headers = {
+            "Authorization": (
+                f'MediaBrowser Client="MediaSage", Device="Server", '
+                f'DeviceId="mediasage-server", Version="1.0.0", Token="{token}"'
+            ),
+            "Content-Type": "application/json",
+        }
+
+        self._connect()
+
+    def _connect(self) -> None:
+        """Attempt to connect and fetch user + library IDs."""
+        if not self.url or not self.token:
+            self._error = "Jellyfin URL and token are required"
+            return
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=15.0) as client:
+                # API keys aren't tied to a specific user, so /Users/Me returns 400.
+                # Instead, list all users and pick the first administrator.
+                resp = client.get(f"{self.url}/Users")
+                resp.raise_for_status()
+                users = resp.json()
+                admin = next((u for u in users if u.get("Policy", {}).get("IsAdministrator")), None)
+                if admin:
+                    self._user_id = admin["Id"]
+                elif users:
+                    self._user_id = users[0]["Id"]
+                else:
+                    self._error = "No users found in Jellyfin"
+                    self._connected = False
+                    return
+
+                # Find the music library
+                resp = client.get(f"{self.url}/Library/MediaFolders")
+                resp.raise_for_status()
+                folders = resp.json().get("Items", [])
+
+                # Look for a library matching the configured name
+                self._library_id = None
+                for folder in folders:
+                    if folder.get("Name", "").lower() == self.music_library_name.lower():
+                        self._library_id = folder["Id"]
+                        break
+
+                # If not found by exact name, take first music collection type
+                if not self._library_id:
+                    for folder in folders:
+                        if folder.get("CollectionType") == "music":
+                            self._library_id = folder["Id"]
+                            break
+
+                if not self._library_id:
+                    self._error = f"Music library '{self.music_library_name}' not found in Jellyfin"
+                    self._connected = False
+                    return
+
+                self._connected = True
+                self._error = None
+                logger.info(
+                    "Connected to Jellyfin: user_id=%s library_id=%s",
+                    self._user_id,
+                    self._library_id,
+                )
+
+        except httpx.ConnectError:
+            self._error = f"Cannot connect to Jellyfin server at {self.url}"
+            self._connected = False
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 401:
+                self._error = "Invalid Jellyfin API key — unauthorized"
+            else:
+                self._error = f"Jellyfin returned HTTP {status}"
+            self._connected = False
+        except Exception as e:
+            self._error = f"Jellyfin connection error: {str(e)}"
+            self._connected = False
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def get_error(self) -> str | None:
+        return self._error
+
+    def get_music_libraries(self) -> list[str]:
+        """Get list of music library names from Jellyfin."""
+        if not self.url or not self.token:
+            return []
+        try:
+            with httpx.Client(headers=self._headers, timeout=10.0) as client:
+                resp = client.get(f"{self.url}/Library/MediaFolders")
+                resp.raise_for_status()
+                folders = resp.json().get("Items", [])
+                return [
+                    f["Name"]
+                    for f in folders
+                    if f.get("CollectionType") == "music"
+                ]
+        except Exception as e:
+            logger.warning("Failed to get Jellyfin music libraries: %s", e)
+            return []
+
+    def get_library_stats(self) -> dict[str, Any]:
+        """Get statistics about the Jellyfin music library."""
+        if not self._connected or not self._library_id:
+            return {"total_tracks": 0, "genres": [], "decades": []}
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=30.0) as client:
+                # Total track count
+                resp = client.get(
+                    f"{self.url}/Items",
+                    params={
+                        "IncludeItemTypes": "Audio",
+                        "Recursive": "true",
+                        "ParentId": self._library_id,
+                        "Limit": 0,
+                    },
+                )
+                resp.raise_for_status()
+                total_tracks = resp.json().get("TotalRecordCount", 0)
+
+                # Genres
+                resp = client.get(
+                    f"{self.url}/Genres",
+                    params={
+                        "IncludeItemTypes": "Audio",
+                        "Recursive": "true",
+                        "ParentId": self._library_id,
+                    },
+                )
+                resp.raise_for_status()
+                genre_items = resp.json().get("Items", [])
+                genres = sorted(
+                    [{"name": g["Name"], "count": None} for g in genre_items],
+                    key=lambda x: x["name"],
+                )
+
+                # Decades: derive from tracks' production years
+                resp = client.get(
+                    f"{self.url}/Items",
+                    params={
+                        "IncludeItemTypes": "Audio",
+                        "Recursive": "true",
+                        "ParentId": self._library_id,
+                        "Fields": "ProductionYear",
+                        "Limit": 50000,
+                    },
+                )
+                resp.raise_for_status()
+                items = resp.json().get("Items", [])
+                decade_set: set[str] = set()
+                for item in items:
+                    year = item.get("ProductionYear")
+                    if year:
+                        decade = f"{(year // 10) * 10}s"
+                        decade_set.add(decade)
+                decades = sorted([{"name": d, "count": None} for d in decade_set],
+                                 key=lambda x: x["name"])
+
+                return {
+                    "total_tracks": total_tracks,
+                    "genres": genres,
+                    "decades": decades,
+                }
+        except Exception as e:
+            logger.exception("Failed to get Jellyfin library stats: %s", e)
+            return {"total_tracks": 0, "genres": [], "decades": [], "error": str(e)}
+
+    def _fields_param(self) -> str:
+        """Standard Fields parameter for all item fetches."""
+        return "Genres,ProductionYear,RunTimeTicks,AlbumArtist,Album,Artists"
+
+    def _item_to_track(self, item: dict) -> Track:
+        """Convert a Jellyfin item dict to a Track model."""
+        item_id = item["Id"]
+        duration_ticks = item.get("RunTimeTicks") or 0
+        duration_ms = duration_ticks // 10000
+
+        return Track(
+            rating_key=item_id,
+            title=item.get("Name", ""),
+            artist=item.get("AlbumArtist") or (item.get("Artists") or [""])[0],
+            album=item.get("Album", ""),
+            duration_ms=duration_ms,
+            year=item.get("ProductionYear"),
+            genres=item.get("Genres", []),
+            art_url=f"/api/art/{item_id}",
+        )
+
+    def get_all_tracks(self) -> list[Track]:
+        """Get all tracks from the Jellyfin library."""
+        if not self._connected or not self._library_id:
+            return []
+
+        try:
+            tracks = []
+            start_index = 0
+            page_size = 1000
+
+            with httpx.Client(headers=self._headers, timeout=120.0) as client:
+                while True:
+                    resp = client.get(
+                        f"{self.url}/Items",
+                        params={
+                            "IncludeItemTypes": "Audio",
+                            "Recursive": "true",
+                            "ParentId": self._library_id,
+                            "Fields": self._fields_param(),
+                            "StartIndex": start_index,
+                            "Limit": page_size,
+                        },
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    items = data.get("Items", [])
+                    if not items:
+                        break
+                    tracks.extend(self._item_to_track(item) for item in items)
+                    if len(tracks) >= data.get("TotalRecordCount", 0):
+                        break
+                    start_index += page_size
+
+            return tracks
+        except Exception as e:
+            logger.exception("Failed to get all Jellyfin tracks: %s", e)
+            return []
+
+    def get_all_albums_metadata(self) -> dict[str, dict[str, Any]]:
+        """Fetch all albums and return mapping of album_id -> metadata."""
+        if not self._connected or not self._library_id:
+            return {}
+
+        try:
+            result = {}
+            start_index = 0
+            page_size = 1000
+
+            with httpx.Client(headers=self._headers, timeout=120.0) as client:
+                while True:
+                    resp = client.get(
+                        f"{self.url}/Items",
+                        params={
+                            "IncludeItemTypes": "MusicAlbum",
+                            "Recursive": "true",
+                            "ParentId": self._library_id,
+                            "Fields": "Genres,ProductionYear",
+                            "StartIndex": start_index,
+                            "Limit": page_size,
+                        },
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    items = data.get("Items", [])
+                    if not items:
+                        break
+                    for item in items:
+                        result[item["Id"]] = {
+                            "genres": item.get("Genres", []),
+                            "year": item.get("ProductionYear"),
+                        }
+                    if len(result) >= data.get("TotalRecordCount", 0):
+                        break
+                    start_index += page_size
+
+            return result
+        except Exception as e:
+            logger.exception("Failed to get Jellyfin album metadata: %s", e)
+            return {}
+
+    def get_tracks_by_filters(
+        self,
+        genres: list[str] | None = None,
+        decades: list[str] | None = None,
+        exclude_live: bool = True,
+        min_rating: int = 0,
+        limit: int = 0,
+    ) -> list[Track]:
+        """Get tracks matching filter criteria from Jellyfin."""
+        if not self._connected or not self._library_id:
+            return []
+
+        try:
+            params: dict[str, Any] = {
+                "IncludeItemTypes": "Audio",
+                "Recursive": "true",
+                "ParentId": self._library_id,
+                "Fields": self._fields_param(),
+            }
+
+            if genres:
+                params["Genres"] = "|".join(genres)
+
+            if decades:
+                years: list[int] = []
+                for decade in decades:
+                    years.extend(_decade_to_years(decade))
+                if years:
+                    params["Years"] = ",".join(str(y) for y in years)
+
+            tracks = []
+            start_index = 0
+            page_size = 1000
+            fetch_limit = limit if limit > 0 else None
+
+            with httpx.Client(headers=self._headers, timeout=120.0) as client:
+                while True:
+                    page_params = dict(params)
+                    page_params["StartIndex"] = start_index
+                    page_params["Limit"] = page_size
+
+                    resp = client.get(f"{self.url}/Items", params=page_params)
+                    resp.raise_for_status()
+                    data = resp.json()
+                    items = data.get("Items", [])
+                    if not items:
+                        break
+
+                    for item in items:
+                        track = self._item_to_track(item)
+                        if exclude_live and is_live_track(track.title, track.album):
+                            continue
+                        tracks.append(track)
+                        if fetch_limit and len(tracks) >= fetch_limit:
+                            return tracks
+
+                    total = data.get("TotalRecordCount", 0)
+                    start_index += page_size
+                    if start_index >= total:
+                        break
+
+            return tracks
+        except Exception as e:
+            logger.exception("Failed to get Jellyfin filtered tracks: %s", e)
+            return []
+
+    def get_random_tracks(
+        self,
+        count: int,
+        exclude_live: bool = True,
+    ) -> list[Track]:
+        """Get random tracks from the Jellyfin library."""
+        if not self._connected or not self._library_id:
+            return []
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=30.0) as client:
+                # Fetch a larger pool and randomly sample
+                resp = client.get(
+                    f"{self.url}/Items",
+                    params={
+                        "IncludeItemTypes": "Audio",
+                        "Recursive": "true",
+                        "ParentId": self._library_id,
+                        "Fields": self._fields_param(),
+                        "SortBy": "Random",
+                        "Limit": count * 3 if exclude_live else count,
+                    },
+                )
+                resp.raise_for_status()
+                items = resp.json().get("Items", [])
+
+                tracks = []
+                for item in items:
+                    track = self._item_to_track(item)
+                    if exclude_live and is_live_track(track.title, track.album):
+                        continue
+                    tracks.append(track)
+                    if len(tracks) >= count:
+                        break
+
+                return tracks
+        except Exception as e:
+            logger.exception("Failed to get random Jellyfin tracks: %s", e)
+            return []
+
+    def get_track_by_key(self, rating_key: str) -> Track | None:
+        """Get a single track by its Jellyfin item ID."""
+        if not self._connected:
+            return None
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=10.0) as client:
+                resp = client.get(
+                    f"{self.url}/Items/{rating_key}",
+                    params={"Fields": "Genres,ProductionYear,RunTimeTicks,AlbumArtist,Album,Artists"},
+                )
+                resp.raise_for_status()
+                item = resp.json()
+                return self._item_to_track(item)
+        except Exception as e:
+            logger.warning("Failed to get Jellyfin track %s: %s", rating_key, e)
+            return None
+
+    def search_tracks(self, query: str) -> list[Track]:
+        """Search for tracks by title or artist in Jellyfin."""
+        if not self._connected or not self._library_id:
+            return []
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=15.0) as client:
+                resp = client.get(
+                    f"{self.url}/Items",
+                    params={
+                        "IncludeItemTypes": "Audio",
+                        "Recursive": "true",
+                        "ParentId": self._library_id,
+                        "SearchTerm": query,
+                        "Fields": "Genres,ProductionYear,RunTimeTicks,AlbumArtist,Album,Artists",
+                        "Limit": 50,
+                    },
+                )
+                resp.raise_for_status()
+                items = resp.json().get("Items", [])
+                return [self._item_to_track(item) for item in items]
+        except Exception as e:
+            logger.warning("Failed to search Jellyfin tracks: %s", e)
+            return []
+
+    def count_tracks_by_filters(
+        self,
+        genres: list[str] | None = None,
+        decades: list[str] | None = None,
+        exclude_live: bool = True,
+        min_rating: int = 0,
+    ) -> int:
+        """Count tracks matching filters. Uses full fetch when exclude_live is needed."""
+        if not self._connected or not self._library_id:
+            return 0
+
+        if exclude_live:
+            # No server-side live filter; must fetch and count
+            tracks = self.get_tracks_by_filters(
+                genres=genres,
+                decades=decades,
+                exclude_live=True,
+                min_rating=min_rating,
+                limit=0,
+            )
+            return len(tracks)
+
+        try:
+            params: dict[str, Any] = {
+                "IncludeItemTypes": "Audio",
+                "Recursive": "true",
+                "ParentId": self._library_id,
+                "Limit": 0,
+            }
+            if genres:
+                params["Genres"] = "|".join(genres)
+            if decades:
+                years: list[int] = []
+                for decade in decades:
+                    years.extend(_decade_to_years(decade))
+                if years:
+                    params["Years"] = ",".join(str(y) for y in years)
+
+            with httpx.Client(headers=self._headers, timeout=30.0) as client:
+                resp = client.get(f"{self.url}/Items", params=params)
+                resp.raise_for_status()
+                return resp.json().get("TotalRecordCount", 0)
+        except Exception as e:
+            logger.warning("Failed to count Jellyfin tracks: %s", e)
+            return 0
+
+    def create_playlist(
+        self,
+        name: str,
+        rating_keys: list[str],
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Create a playlist in Jellyfin."""
+        if not self._connected or not self._user_id:
+            return {"success": False, "error": "Not connected to Jellyfin"}
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=30.0) as client:
+                # Create playlist
+                body = {
+                    "Name": name,
+                    "Ids": rating_keys,
+                    "UserId": self._user_id,
+                    "MediaType": "Audio",
+                }
+                resp = client.post(f"{self.url}/Playlists", json=body)
+                resp.raise_for_status()
+                playlist_data = resp.json()
+                playlist_id = playlist_data.get("Id") or playlist_data.get("id")
+
+                if not playlist_id:
+                    return {"success": False, "error": "Playlist created but no ID returned"}
+
+                # Note: Jellyfin doesn't have a built-in description field for playlists
+                # in the same way Plex does; we skip setting it silently.
+
+                return {
+                    "success": True,
+                    "playlist_id": playlist_id,
+                    "playlist_url": None,
+                    "tracks_added": len(rating_keys),
+                    "tracks_skipped": 0,
+                }
+        except Exception as e:
+            logger.exception("Failed to create Jellyfin playlist '%s'", name)
+            return {"success": False, "error": str(e)}
+
+    def update_playlist(
+        self,
+        playlist_id: str,
+        rating_keys: list[str],
+        mode: str = "replace",
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Update a Jellyfin playlist by replacing or appending tracks."""
+        if not self._connected or not self._user_id:
+            return {"success": False, "error": "Not connected to Jellyfin"}
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=30.0) as client:
+                if mode == "replace":
+                    # Remove all existing items, then add new ones
+                    items_resp = client.get(
+                        f"{self.url}/Playlists/{playlist_id}/Items",
+                        params={"UserId": self._user_id},
+                    )
+                    items_resp.raise_for_status()
+                    existing_items = items_resp.json().get("Items", [])
+                    existing_ids = [item["PlaylistItemId"] for item in existing_items if "PlaylistItemId" in item]
+
+                    if existing_ids:
+                        del_resp = client.delete(
+                            f"{self.url}/Playlists/{playlist_id}/Items",
+                            params={"EntryIds": ",".join(existing_ids)},
+                        )
+                        del_resp.raise_for_status()
+
+                # Add new tracks
+                add_resp = client.post(
+                    f"{self.url}/Playlists/{playlist_id}/Items",
+                    params={
+                        "Ids": ",".join(rating_keys),
+                        "UserId": self._user_id,
+                    },
+                )
+                add_resp.raise_for_status()
+
+                return {
+                    "success": True,
+                    "tracks_added": len(rating_keys),
+                    "tracks_skipped": 0,
+                    "duplicates_skipped": 0,
+                    "playlist_url": None,
+                }
+        except Exception as e:
+            logger.exception("Failed to update Jellyfin playlist %s", playlist_id)
+            return {"success": False, "error": str(e)}
+
+    def get_playlists(self) -> list[PlexPlaylistInfo]:
+        """Get all audio playlists from Jellyfin."""
+        if not self._connected or not self._user_id:
+            return []
+
+        try:
+            with httpx.Client(headers=self._headers, timeout=15.0) as client:
+                resp = client.get(
+                    f"{self.url}/Items",
+                    params={
+                        "IncludeItemTypes": "Playlist",
+                        "Recursive": "true",
+                        "UserId": self._user_id,
+                        "Fields": "ChildCount",
+                    },
+                )
+                resp.raise_for_status()
+                items = resp.json().get("Items", [])
+
+                result = []
+                for item in items:
+                    # Filter to audio playlists (MediaType == Audio or no restriction)
+                    media_type = item.get("MediaType", "")
+                    if media_type and media_type.lower() not in ("audio", ""):
+                        continue
+                    result.append(PlexPlaylistInfo(
+                        rating_key=item["Id"],
+                        title=item["Name"],
+                        track_count=item.get("ChildCount", 0),
+                    ))
+                return sorted(result, key=lambda p: p.title.lower())
+        except Exception as e:
+            logger.exception("Failed to get Jellyfin playlists: %s", e)
+            return []
+
+    def get_art_url(self, item_id: str) -> str | None:
+        """Get the direct art URL for a Jellyfin item.
+
+        Returns the full Jellyfin URL for the primary image, which main.py will proxy.
+        """
+        if not self._connected or not self.url:
+            return None
+        return f"{self.url}/Items/{item_id}/Images/Primary"
+
+    def get_machine_identifier(self) -> str | None:
+        """Get the Jellyfin server ID (for library cache server-change detection)."""
+        try:
+            with httpx.Client(headers=self._headers, timeout=10.0) as client:
+                resp = client.get(f"{self.url}/System/Info")
+                resp.raise_for_status()
+                return resp.json().get("Id")
+        except Exception:
+            return None
+
+    def get_server_name(self) -> str | None:
+        """Get the Jellyfin server name."""
+        try:
+            with httpx.Client(headers=self._headers, timeout=10.0) as client:
+                resp = client.get(f"{self.url}/System/Info")
+                resp.raise_for_status()
+                return resp.json().get("ServerName")
+        except Exception:
+            return None
+
+
+def get_jellyfin_client() -> JellyfinClient | None:
+    """Get the global Jellyfin client instance."""
+    return _jellyfin_client
+
+
+def init_jellyfin_client(url: str, token: str, music_library: str = "Music") -> JellyfinClient:
+    """Initialize the global Jellyfin client."""
+    global _jellyfin_client
+    _jellyfin_client = JellyfinClient(url, token, music_library)
+    return _jellyfin_client

--- a/backend/library_cache.py
+++ b/backend/library_cache.py
@@ -457,53 +457,78 @@ def sync_library(
         conn.execute("UPDATE sync_state SET track_count = 0 WHERE id = 1")
         conn.commit()
 
-        # Phase 1: Fetch albums for genre/year mapping
-        logger.info("Fetching album metadata from Plex...")
-        album_metadata = plex_client.get_all_albums_metadata()
-        logger.info("Got metadata for %d albums", len(album_metadata))
+        # Detect client type: Plex (has get_all_raw_tracks) vs generic (Track models)
+        use_raw = hasattr(plex_client, "get_all_raw_tracks")
 
-        # Phase 2: Fetch all tracks from Plex
-        with _sync_lock:
-            _sync_state["phase"] = "fetching"
-        logger.info("Fetching all tracks from Plex (this may take 30-60s)...")
-        all_tracks = plex_client.get_all_raw_tracks()
+        if use_raw:
+            # Phase 1 (Plex): Fetch albums for genre/year mapping
+            logger.info("Fetching album metadata from media server...")
+            album_metadata = plex_client.get_all_albums_metadata()
+            logger.info("Got metadata for %d albums", len(album_metadata))
+
+            # Phase 2 (Plex): Fetch all raw tracks
+            with _sync_lock:
+                _sync_state["phase"] = "fetching"
+            logger.info("Fetching all tracks from media server (this may take 30-60s)...")
+            all_tracks = plex_client.get_all_raw_tracks()
+        else:
+            # Phase 1+2 (Jellyfin/generic): Fetch Track models directly
+            with _sync_lock:
+                _sync_state["phase"] = "fetching"
+            logger.info("Fetching all tracks from media server (this may take 30-60s)...")
+            all_tracks = plex_client.get_all_tracks()
+            album_metadata = {}  # Not needed; Track models already have genres/year
+
         total = len(all_tracks)
-        logger.info("Got %d tracks from Plex", total)
+        logger.info("Got %d tracks from media server", total)
 
         with _sync_lock:
             _sync_state["total"] = total
             _sync_state["phase"] = "processing"
 
-        # Phase 3: Process tracks in batches with album metadata lookup
+        # Phase 3: Process tracks in batches
         synced_count = 0
         batch_data = []
 
         for i, track in enumerate(all_tracks):
-            # Extract track data
-            title = track.title
-            album = getattr(track, "parentTitle", "") or ""
-            artist = getattr(track, "grandparentTitle", "") or "Unknown Artist"
-
-            # Look up genres and year from album metadata using parentRatingKey
-            parent_key = str(getattr(track, "parentRatingKey", ""))
-            album_data = album_metadata.get(parent_key, {})
-            genres = album_data.get("genres", [])
-            year = album_data.get("year")
-
-            # Extract play history data
-            view_count = getattr(track, "viewCount", 0) or 0
-            last_viewed_at_raw = getattr(track, "lastViewedAt", None)
-            last_viewed_at = last_viewed_at_raw.isoformat() if last_viewed_at_raw else None
+            if use_raw:
+                # Raw Plex track objects
+                title = track.title
+                album = getattr(track, "parentTitle", "") or ""
+                artist = getattr(track, "grandparentTitle", "") or "Unknown Artist"
+                parent_key = str(getattr(track, "parentRatingKey", ""))
+                album_data = album_metadata.get(parent_key, {})
+                genres = album_data.get("genres", [])
+                year = album_data.get("year")
+                view_count = getattr(track, "viewCount", 0) or 0
+                last_viewed_at_raw = getattr(track, "lastViewedAt", None)
+                last_viewed_at = last_viewed_at_raw.isoformat() if last_viewed_at_raw else None
+                rating_key = str(track.ratingKey)
+                duration_ms = track.duration or 0
+                user_rating = getattr(track, "userRating", None)
+            else:
+                # Track model objects (Jellyfin)
+                title = track.title
+                album = track.album
+                artist = track.artist or "Unknown Artist"
+                parent_key = ""
+                genres = track.genres
+                year = track.year
+                view_count = 0
+                last_viewed_at = None
+                rating_key = track.rating_key
+                duration_ms = track.duration_ms
+                user_rating = track.user_rating
 
             batch_data.append((
-                str(track.ratingKey),
+                rating_key,
                 title,
                 artist,
                 album,
-                track.duration or 0,
+                duration_ms,
                 year,
                 json.dumps(genres),  # Store genres as JSON array
-                getattr(track, "userRating", None),
+                user_rating,
                 _is_live_version(title, album),
                 parent_key,
                 view_count,

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from fastapi.responses import HTMLResponse
 from starlette.responses import StreamingResponse
 import httpx
 
-from backend.config import get_config, update_config_values, load_user_yaml_config, save_user_config, ConfigSaveError
+from backend.config import get_config, get_current_media_client, update_config_values, load_user_yaml_config, save_user_config, ConfigSaveError
 from backend.version import get_version
 from backend.models import (
     AlbumCandidate,
@@ -66,11 +66,14 @@ from backend.models import (
     UpdatePlaylistResponse,
     ValidateAIRequest,
     ValidateAIResponse,
+    ValidateJellyfinRequest,
+    ValidateJellyfinResponse,
     ValidatePlexRequest,
     ValidatePlexResponse,
     album_key,
 )
 from backend.plex_client import PlexClient as PlexClientInstance, get_plex_client, init_plex_client
+from backend.jellyfin_client import JellyfinClient, get_jellyfin_client, init_jellyfin_client
 from backend import library_cache
 from backend.llm_client import (
     TOKENS_PER_ALBUM,
@@ -104,6 +107,14 @@ async def lifespan(app: FastAPI):
             config.plex.music_library,
         )
 
+    # Initialize Jellyfin client if configured
+    if config.jellyfin.url and config.jellyfin.token:
+        init_jellyfin_client(
+            config.jellyfin.url,
+            config.jellyfin.token,
+            config.jellyfin.music_library,
+        )
+
     # Initialize LLM client if configured
     # Local providers (ollama, custom) don't need an API key
     if config.llm.api_key or config.llm.provider in ("ollama", "custom"):
@@ -113,13 +124,13 @@ async def lifespan(app: FastAPI):
     library_cache.ensure_db_initialized().close()
 
     # Auto-sync if a migration was applied and existing tracks need re-sync
-    plex_client = get_plex_client()
-    if library_cache.needs_resync() and plex_client and plex_client.is_connected():
+    _media_client = get_current_media_client()
+    if library_cache.needs_resync() and _media_client and _media_client.is_connected():
         logger.info("Schema migration detected — starting automatic library re-sync")
 
         async def _run_resync():
             try:
-                await asyncio.to_thread(library_cache.sync_library, plex_client)
+                await asyncio.to_thread(library_cache.sync_library, _media_client)
             except Exception as e:
                 logger.error("Auto-resync failed: %s", e)
 
@@ -167,12 +178,22 @@ def _build_config_response(config, plex_client) -> ConfigResponse:
     gen_costs = get_model_cost(generation_model, config.llm)
     analysis_costs = get_model_cost(analysis_model, config.llm)
 
+    # Determine music_library based on active media server
+    if config.media_server == "jellyfin":
+        active_music_library = config.jellyfin.music_library
+    else:
+        active_music_library = config.plex.music_library
+
     return ConfigResponse(
         version=get_version(),
+        media_server=config.media_server,
         plex_url=config.plex.url,
         plex_connected=plex_client.is_connected() if plex_client else False,
         plex_token_set=bool(config.plex.token),
-        music_library=config.plex.music_library,
+        music_library=active_music_library,
+        jellyfin_url=config.jellyfin.url,
+        jellyfin_token_set=bool(config.jellyfin.token),
+        jellyfin_music_library=config.jellyfin.music_library,
         llm_provider=config.llm.provider,
         llm_configured=_is_llm_configured(config),
         llm_api_key_set=bool(config.llm.api_key),
@@ -203,12 +224,13 @@ def _build_config_response(config, plex_client) -> ConfigResponse:
 async def health_check() -> HealthResponse:
     """Check application health status."""
     config = get_config()
-    plex_client = get_plex_client()
+    media_client = get_current_media_client()
 
     return HealthResponse(
         status="healthy",
-        plex_connected=plex_client.is_connected() if plex_client else False,
+        plex_connected=media_client.is_connected() if media_client else False,
         llm_configured=_is_llm_configured(config),
+        media_server=config.media_server,
     )
 
 
@@ -222,6 +244,7 @@ async def setup_status() -> SetupStatusResponse:
     """Get onboarding checklist state for the setup wizard."""
     config = get_config()
     plex_client = get_plex_client()
+    jellyfin_client = get_jellyfin_client()
 
     # Check data dir writable by actually creating+deleting a temp file
     # (more reliable than os.access for Docker bind mounts)
@@ -239,7 +262,18 @@ async def setup_status() -> SetupStatusResponse:
     # Plex status
     plex_connected = plex_client.is_connected() if plex_client else False
     plex_error = plex_client.get_error() if plex_client and not plex_connected else None
-    music_libraries = plex_client.get_music_libraries() if plex_client and plex_connected else []
+
+    # Jellyfin status
+    jellyfin_connected = jellyfin_client.is_connected() if jellyfin_client else False
+    jellyfin_error = jellyfin_client.get_error() if jellyfin_client and not jellyfin_connected else None
+
+    # Music libraries from active server
+    if config.media_server == "jellyfin" and jellyfin_connected and jellyfin_client:
+        music_libraries = jellyfin_client.get_music_libraries()
+    elif plex_connected and plex_client:
+        music_libraries = plex_client.get_music_libraries()
+    else:
+        music_libraries = []
 
     # LLM status
     llm_configured = _is_llm_configured(config)
@@ -268,9 +302,13 @@ async def setup_status() -> SetupStatusResponse:
         process_uid=getattr(os, "getuid", lambda: 0)(),
         process_gid=getattr(os, "getgid", lambda: 0)(),
         data_dir=str(data_dir),
+        media_server=config.media_server,
         plex_connected=plex_connected,
         plex_error=plex_error,
         plex_from_env=bool(os.environ.get("PLEX_URL")),
+        jellyfin_connected=jellyfin_connected,
+        jellyfin_error=jellyfin_error,
+        jellyfin_from_env=bool(os.environ.get("JELLYFIN_URL")),
         music_libraries=music_libraries,
         llm_configured=llm_configured,
         llm_provider=config.llm.provider,
@@ -320,6 +358,46 @@ async def setup_validate_plex(request: ValidatePlexRequest) -> ValidatePlexRespo
         success=True,
         server_name=server_name,
         music_libraries=music_libraries,
+    )
+
+
+@app.post("/api/setup/validate-jellyfin", response_model=ValidateJellyfinResponse)
+async def setup_validate_jellyfin(request: ValidateJellyfinRequest) -> ValidateJellyfinResponse:
+    """Validate Jellyfin credentials and save on success."""
+    try:
+        temp_client = await asyncio.to_thread(
+            JellyfinClient, request.jellyfin_url, request.jellyfin_token, request.music_library
+        )
+    except Exception as e:
+        return ValidateJellyfinResponse(success=False, error=str(e))
+
+    if not temp_client.is_connected():
+        return ValidateJellyfinResponse(
+            success=False,
+            error=temp_client.get_error() or "Connection failed",
+        )
+
+    music_libraries = temp_client.get_music_libraries()
+    server_name = temp_client.get_server_name()
+    user_id = temp_client._user_id
+
+    try:
+        update_config_values({
+            "media_server": "jellyfin",
+            "jellyfin_url": request.jellyfin_url,
+            "jellyfin_token": request.jellyfin_token,
+            "jellyfin_music_library": request.music_library,
+        })
+    except ConfigSaveError as e:
+        return ValidateJellyfinResponse(success=False, error=str(e))
+
+    init_jellyfin_client(request.jellyfin_url, request.jellyfin_token, request.music_library)
+
+    return ValidateJellyfinResponse(
+        success=True,
+        server_name=server_name,
+        music_libraries=music_libraries,
+        user_id=user_id,
     )
 
 
@@ -455,6 +533,14 @@ async def update_configuration(request: UpdateConfigRequest) -> ConfigResponse:
             config.plex.music_library,
         )
 
+    if any(k in updates for k in ["jellyfin_url", "jellyfin_token", "jellyfin_music_library"]):
+        if config.jellyfin.url and config.jellyfin.token:
+            init_jellyfin_client(
+                config.jellyfin.url,
+                config.jellyfin.token,
+                config.jellyfin.music_library,
+            )
+
     if any(k in updates for k in ["llm_provider", "llm_api_key", "model_analysis", "model_generation", "ollama_url", "custom_url"]):
         init_llm_client(config.llm)
 
@@ -508,7 +594,7 @@ async def ollama_model_info(
 @app.get("/api/library/status", response_model=LibraryCacheStatusResponse)
 async def get_library_status() -> LibraryCacheStatusResponse:
     """Get library cache status for UI polling."""
-    plex_client = get_plex_client()
+    media_client = get_current_media_client()
 
     # Get sync state from cache module
     state = library_cache.get_sync_state()
@@ -528,20 +614,20 @@ async def get_library_status() -> LibraryCacheStatusResponse:
         is_syncing=state["is_syncing"],
         sync_progress=sync_progress,
         error=state["error"],
-        plex_connected=plex_client.is_connected() if plex_client else False,
+        plex_connected=media_client.is_connected() if media_client else False,
         needs_resync=library_cache.needs_resync(),
     )
 
 
 @app.post("/api/library/sync", response_model=SyncTriggerResponse)
 async def trigger_library_sync() -> SyncTriggerResponse:
-    """Trigger library sync from Plex.
+    """Trigger library sync from the configured media server.
 
     Always starts sync in background so progress can be polled.
     """
-    plex_client = get_plex_client()
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    media_client = get_current_media_client()
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
 
     # Check if already syncing
     progress = library_cache.get_sync_progress()
@@ -550,7 +636,7 @@ async def trigger_library_sync() -> SyncTriggerResponse:
 
     # Always run sync in background so progress can be polled
     asyncio.create_task(
-        asyncio.to_thread(library_cache.sync_library, plex_client)
+        asyncio.to_thread(library_cache.sync_library, media_client)
     )
     return SyncTriggerResponse(started=True, blocking=False)
 
@@ -563,11 +649,11 @@ async def trigger_library_sync() -> SyncTriggerResponse:
 @app.get("/api/library/stats", response_model=LibraryStatsResponse)
 async def get_library_stats() -> LibraryStatsResponse:
     """Get library statistics."""
-    plex_client = get_plex_client()
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    media_client = get_current_media_client()
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
 
-    stats = await asyncio.to_thread(plex_client.get_library_stats)
+    stats = await asyncio.to_thread(media_client.get_library_stats)
     return LibraryStatsResponse(
         total_tracks=stats.get("total_tracks", 0),
         genres=[GenreCount(**g) for g in stats.get("genres", [])],
@@ -589,13 +675,13 @@ async def get_library_stats_cached() -> LibraryStatsResponse:
 @app.get("/api/library/search", response_model=list[Track])
 async def search_library(q: str = Query(..., description="Search query")) -> list[Track]:
     """Search for tracks in the library."""
-    plex_client = get_plex_client()
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    media_client = get_current_media_client()
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
 
     # Normalize smart/curly quotes to straight quotes (iOS auto-correction)
     normalized = q.replace("\u2018", "'").replace("\u2019", "'").replace("\u201c", '"').replace("\u201d", '"')
-    return await asyncio.to_thread(plex_client.search_tracks, normalized)
+    return await asyncio.to_thread(media_client.search_tracks, normalized)
 
 
 # =============================================================================
@@ -606,11 +692,11 @@ async def search_library(q: str = Query(..., description="Search query")) -> lis
 @app.post("/api/analyze/prompt", response_model=AnalyzePromptResponse)
 async def analyze_prompt(request: AnalyzePromptRequest) -> AnalyzePromptResponse:
     """Analyze a natural language prompt to suggest filters."""
-    plex_client = get_plex_client()
+    media_client = get_current_media_client()
     llm_client = get_llm_client()
 
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
     if not llm_client:
         raise HTTPException(status_code=503, detail="LLM not configured")
 
@@ -625,16 +711,16 @@ async def analyze_prompt(request: AnalyzePromptRequest) -> AnalyzePromptResponse
 @app.post("/api/analyze/track", response_model=AnalyzeTrackResponse)
 async def analyze_track(request: AnalyzeTrackRequest) -> AnalyzeTrackResponse:
     """Analyze a seed track for dimensions."""
-    plex_client = get_plex_client()
+    media_client = get_current_media_client()
     llm_client = get_llm_client()
 
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
     if not llm_client:
         raise HTTPException(status_code=503, detail="LLM not configured")
 
     # Get the track
-    track = await asyncio.to_thread(plex_client.get_track_by_key, request.rating_key)
+    track = await asyncio.to_thread(media_client.get_track_by_key, request.rating_key)
     if not track:
         raise HTTPException(status_code=404, detail="Track not found")
 
@@ -672,13 +758,14 @@ async def preview_filters(request: FilterPreviewRequest) -> FilterPreviewRespons
             exclude_live=exclude_live,
         )
 
-    # Fall back to Plex if cache is empty
+    # Fall back to media server if cache is empty
     if matching_tracks < 0:
-        if not plex_client or not plex_client.is_connected():
-            raise HTTPException(status_code=503, detail="Plex not connected")
+        media_client = get_current_media_client()
+        if not media_client or not media_client.is_connected():
+            raise HTTPException(status_code=503, detail="Media server not connected")
 
         matching_tracks = await asyncio.to_thread(
-            plex_client.count_tracks_by_filters,
+            media_client.count_tracks_by_filters,
             genres=genres,
             decades=decades,
             exclude_live=exclude_live,
@@ -737,11 +824,11 @@ async def preview_filters(request: FilterPreviewRequest) -> FilterPreviewRespons
 @app.post("/api/generate/stream")
 async def generate_playlist_sse(request: GenerateRequest) -> StreamingResponse:
     """Generate a playlist with streaming progress updates."""
-    plex_client = get_plex_client()
+    media_client = get_current_media_client()
     llm_client = get_llm_client()
 
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
     if not llm_client:
         raise HTTPException(status_code=503, detail="LLM not configured")
 
@@ -750,7 +837,7 @@ async def generate_playlist_sse(request: GenerateRequest) -> StreamingResponse:
     selected_dimensions = None
     if request.seed_track:
         seed_track = await asyncio.to_thread(
-            plex_client.get_track_by_key, request.seed_track.rating_key
+            media_client.get_track_by_key, request.seed_track.rating_key
         )
         if not seed_track:
             raise HTTPException(status_code=404, detail="Seed track not found")
@@ -789,13 +876,13 @@ async def generate_playlist_sse(request: GenerateRequest) -> StreamingResponse:
 
 @app.post("/api/playlist", response_model=SavePlaylistResponse)
 async def save_playlist(request: SavePlaylistRequest) -> SavePlaylistResponse:
-    """Save a playlist to Plex."""
-    plex_client = get_plex_client()
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    """Save a playlist to the configured media server."""
+    media_client = get_current_media_client()
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
 
     result = await asyncio.to_thread(
-        plex_client.create_playlist,
+        media_client.create_playlist,
         request.name,
         request.rating_keys,
         request.description,
@@ -850,15 +937,25 @@ async def get_plex_playlists() -> list[PlexPlaylistInfo]:
     return await asyncio.to_thread(plex_client.get_playlists)
 
 
+@app.get("/api/jellyfin/playlists", response_model=list[PlexPlaylistInfo])
+async def get_jellyfin_playlists() -> list[PlexPlaylistInfo]:
+    """List audio playlists on the Jellyfin server."""
+    jellyfin_client = get_jellyfin_client()
+    if not jellyfin_client or not jellyfin_client.is_connected():
+        raise HTTPException(status_code=503, detail="Jellyfin not connected")
+
+    return await asyncio.to_thread(jellyfin_client.get_playlists)
+
+
 @app.post("/api/playlist/update", response_model=UpdatePlaylistResponse)
 async def update_playlist(request: UpdatePlaylistRequest) -> UpdatePlaylistResponse:
-    """Update an existing Plex playlist by replacing or appending tracks."""
-    plex_client = get_plex_client()
-    if not plex_client or not plex_client.is_connected():
-        raise HTTPException(status_code=503, detail="Plex not connected")
+    """Update an existing playlist by replacing or appending tracks."""
+    media_client = get_current_media_client()
+    if not media_client or not media_client.is_connected():
+        raise HTTPException(status_code=503, detail="Media server not connected")
 
     result = await asyncio.to_thread(
-        plex_client.update_playlist,
+        media_client.update_playlist,
         request.playlist_id,
         request.rating_keys,
         request.mode,
@@ -1564,13 +1661,37 @@ async def delete_result(result_id: str):
 
 @app.get("/api/art/{rating_key}")
 async def get_album_art(rating_key: str):
-    """Proxy album art from Plex to avoid exposing token to browser."""
+    """Proxy album art from Plex or Jellyfin to avoid exposing credentials to browser."""
+    config = get_config()
+
+    if config.media_server == "jellyfin":
+        jellyfin_client = get_jellyfin_client()
+        if not jellyfin_client or not jellyfin_client.is_connected():
+            raise HTTPException(status_code=503, detail="Jellyfin not connected")
+
+        art_url = jellyfin_client.get_art_url(rating_key)
+        if art_url:
+            try:
+                proxy_client = await _get_art_proxy_client()
+                response = await proxy_client.get(
+                    art_url,
+                    headers={"Authorization": f'MediaBrowser Token="{config.jellyfin.token}"'},
+                )
+                if response.status_code == 200:
+                    return Response(
+                        content=response.content,
+                        media_type=response.headers.get("content-type", "image/jpeg"),
+                    )
+            except Exception:
+                logger.debug("Jellyfin art proxy failed for item_id=%s", rating_key, exc_info=True)
+
+        raise HTTPException(status_code=404, detail="Art not available")
+
+    # Plex path (default)
     if not rating_key.isdigit():
         raise HTTPException(status_code=400, detail="Invalid rating key format")
 
     plex_client = get_plex_client()
-    config = get_config()
-
     if not plex_client or not plex_client.is_connected():
         raise HTTPException(status_code=503, detail="Plex not connected")
 

--- a/backend/media_client.py
+++ b/backend/media_client.py
@@ -1,0 +1,172 @@
+"""Abstract base class and shared utilities for media server clients."""
+
+import re
+from abc import ABC, abstractmethod
+from typing import Any
+
+from unidecode import unidecode
+
+from backend.models import Track
+
+# Patterns for detecting live recordings
+DATE_PATTERN = r"\d{4}[-/]\d{2}[-/]\d{2}"
+LIVE_KEYWORDS = r"\b(?:live|concert|sbd|bootleg)\b"
+
+
+def simplify_string(s: str) -> str:
+    """Normalize string for fuzzy comparison."""
+    s = s.lower()
+    s = re.sub(r"[^\w\s]", "", s)  # Remove punctuation
+    s = unidecode(s)  # Normalize unicode (café → cafe)
+    return s
+
+
+def normalize_artist(name: str) -> list[str]:
+    """Return variations of artist name for matching."""
+    variations = [name]
+    if " and " in name.lower():
+        variations.append(name.replace(" and ", " & ").replace(" And ", " & "))
+    elif " & " in name:
+        variations.append(name.replace(" & ", " and "))
+    return variations
+
+
+def is_live_track(title: str, album_title: str) -> bool:
+    """Check if a track appears to be a live recording based on title strings.
+
+    Args:
+        title: Track title
+        album_title: Album title
+
+    Returns:
+        True if track appears to be a live version
+    """
+    for text in [album_title, title]:
+        if re.search(DATE_PATTERN, text):
+            return True
+        if re.search(LIVE_KEYWORDS, text, re.IGNORECASE):
+            return True
+    return False
+
+
+class BaseMediaClient(ABC):
+    """Abstract base class for media server clients (Plex, Jellyfin, etc.)."""
+
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Check if connected to the media server."""
+        ...
+
+    @abstractmethod
+    def get_error(self) -> str | None:
+        """Get the last error message, if any."""
+        ...
+
+    @abstractmethod
+    def get_music_libraries(self) -> list[str]:
+        """Get list of music library names."""
+        ...
+
+    @abstractmethod
+    def get_library_stats(self) -> dict[str, Any]:
+        """Get statistics about the music library.
+
+        Returns:
+            Dict with total_tracks, genres, and decades
+        """
+        ...
+
+    @abstractmethod
+    def get_all_tracks(self) -> list[Track]:
+        """Get all tracks from the library as Track models."""
+        ...
+
+    @abstractmethod
+    def get_all_albums_metadata(self) -> dict[str, dict[str, Any]]:
+        """Fetch all albums and return mapping of rating_key -> metadata.
+
+        Returns:
+            Dict mapping album rating_key (as string) to dict with 'genres' and 'year'
+        """
+        ...
+
+    @abstractmethod
+    def get_tracks_by_filters(
+        self,
+        genres: list[str] | None = None,
+        decades: list[str] | None = None,
+        exclude_live: bool = True,
+        min_rating: int = 0,
+        limit: int = 0,
+    ) -> list[Track]:
+        """Get tracks matching filter criteria."""
+        ...
+
+    @abstractmethod
+    def get_random_tracks(
+        self,
+        count: int,
+        exclude_live: bool = True,
+    ) -> list[Track]:
+        """Get random tracks from the library."""
+        ...
+
+    @abstractmethod
+    def get_track_by_key(self, rating_key: str) -> Track | None:
+        """Get a single track by its rating key."""
+        ...
+
+    @abstractmethod
+    def search_tracks(self, query: str) -> list[Track]:
+        """Search for tracks by title or artist."""
+        ...
+
+    @abstractmethod
+    def count_tracks_by_filters(
+        self,
+        genres: list[str] | None = None,
+        decades: list[str] | None = None,
+        exclude_live: bool = True,
+        min_rating: int = 0,
+    ) -> int:
+        """Count tracks matching filter criteria (fast, no full fetch)."""
+        ...
+
+    @abstractmethod
+    def create_playlist(
+        self,
+        name: str,
+        rating_keys: list[str],
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Create a new playlist.
+
+        Returns:
+            Dict with success, playlist_id, playlist_url, tracks_added, tracks_skipped
+        """
+        ...
+
+    @abstractmethod
+    def update_playlist(
+        self,
+        playlist_id: str,
+        rating_keys: list[str],
+        mode: str = "replace",
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Update an existing playlist by replacing or appending tracks."""
+        ...
+
+    @abstractmethod
+    def get_playlists(self) -> list:
+        """Get all audio playlists from the media server."""
+        ...
+
+    @abstractmethod
+    def get_art_url(self, item_id: str) -> str | None:
+        """Get the art URL for an item (for backend proxying).
+
+        Returns:
+            Full URL string for art, or None if not available
+        """
+        ...

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,7 +18,7 @@ def album_key(artist: str, album: str, lower: bool = True) -> str:
 
 
 class Track(BaseModel):
-    """A music track from the Plex library."""
+    """A music track from the media library."""
 
     rating_key: str
     title: str
@@ -28,6 +28,7 @@ class Track(BaseModel):
     year: int | None = None
     genres: list[str] = []
     art_url: str | None = None
+    user_rating: int | None = None  # 0-10 scale (Plex/Jellyfin both use this)
 
     @property
     def duration_formatted(self) -> str:
@@ -93,6 +94,14 @@ class PlexConfig(BaseModel):
     music_library: str = "Music"
 
 
+class JellyfinConfig(BaseModel):
+    """Jellyfin server connection settings."""
+
+    url: str = ""
+    token: str = ""  # API key from Jellyfin admin > API Keys
+    music_library: str = "Music"
+
+
 class LLMConfig(BaseModel):
     """LLM provider settings."""
 
@@ -126,7 +135,9 @@ class DefaultsConfig(BaseModel):
 class AppConfig(BaseModel):
     """Root configuration object."""
 
+    media_server: Literal["plex", "jellyfin"] = "plex"
     plex: PlexConfig
+    jellyfin: JellyfinConfig = JellyfinConfig()
     llm: LLMConfig
     defaults: DefaultsConfig = DefaultsConfig()
 
@@ -253,12 +264,12 @@ class GenerateResponse(BaseModel):
 
 
 def _validate_rating_keys(v: list[str]) -> list[str]:
-    """Validate a list of Plex rating keys (must be non-empty, all numeric)."""
+    """Validate a list of media server item IDs (must be non-empty).
+
+    Accepts Plex numeric IDs and Jellyfin UUID-style hex IDs.
+    """
     if not v:
         raise ValueError("At least one track is required")
-    for key in v:
-        if not key.isdigit():
-            raise ValueError(f"Invalid rating key: {key}")
     return v
 
 
@@ -316,6 +327,10 @@ class PlexPlaylistInfo(BaseModel):
     track_count: int
 
 
+# Alias used for Jellyfin and any media-server-agnostic contexts
+MediaPlaylistInfo = PlexPlaylistInfo
+
+
 class PlexClientInfo(BaseModel):
     """Online Plex client info."""
 
@@ -343,8 +358,8 @@ class UpdatePlaylistRequest(BaseModel):
     @field_validator("playlist_id")
     @classmethod
     def validate_playlist_id(cls, v: str) -> str:
-        if v != "__scratch__" and not v.isdigit():
-            raise ValueError("playlist_id must be '__scratch__' or a numeric rating key")
+        if not v:
+            raise ValueError("playlist_id cannot be empty")
         return v
 
     @field_validator("rating_keys")
@@ -400,10 +415,15 @@ class ConfigResponse(BaseModel):
     """Config without secrets for display."""
 
     version: str
+    media_server: str = "plex"
     plex_url: str
     plex_connected: bool
     plex_token_set: bool  # True if token is configured (without revealing it)
     music_library: str | None
+    # Jellyfin fields
+    jellyfin_url: str = ""
+    jellyfin_token_set: bool = False
+    jellyfin_music_library: str = "Music"
     llm_provider: str
     llm_configured: bool
     llm_api_key_set: bool  # True if API key is configured (without revealing it)
@@ -428,9 +448,14 @@ class ConfigResponse(BaseModel):
 class UpdateConfigRequest(BaseModel):
     """Partial config update."""
 
+    media_server: str | None = None
     plex_url: str | None = None
     plex_token: str | None = None
     music_library: str | None = None
+    # Jellyfin fields
+    jellyfin_url: str | None = None
+    jellyfin_token: str | None = None
+    jellyfin_music_library: str | None = None
     llm_provider: str | None = None
     llm_api_key: str | None = None
     model_analysis: str | None = None
@@ -448,6 +473,7 @@ class HealthResponse(BaseModel):
     status: str
     plex_connected: bool
     llm_configured: bool
+    media_server: str = "plex"
 
 
 class ErrorResponse(BaseModel):
@@ -804,9 +830,13 @@ class SetupStatusResponse(BaseModel):
     process_uid: int = 0
     process_gid: int = 0
     data_dir: str = ""
+    media_server: str = "plex"
     plex_connected: bool
     plex_error: str | None = None
     plex_from_env: bool = False
+    jellyfin_connected: bool = False
+    jellyfin_error: str | None = None
+    jellyfin_from_env: bool = False
     music_libraries: list[str] = []
     llm_configured: bool
     llm_provider: str = ""
@@ -833,6 +863,24 @@ class ValidatePlexResponse(BaseModel):
     error: str | None = None
     server_name: str | None = None
     music_libraries: list[str] = []
+
+
+class ValidateJellyfinRequest(BaseModel):
+    """Request to validate Jellyfin credentials during setup."""
+
+    jellyfin_url: str
+    jellyfin_token: str
+    music_library: str = "Music"
+
+
+class ValidateJellyfinResponse(BaseModel):
+    """Response from Jellyfin validation."""
+
+    success: bool
+    error: str | None = None
+    server_name: str | None = None
+    music_libraries: list[str] = []
+    user_id: str | None = None
 
 
 class ValidateAIRequest(BaseModel):

--- a/backend/plex_client.py
+++ b/backend/plex_client.py
@@ -13,6 +13,7 @@ from plexapi.server import PlexServer
 from requests.exceptions import ConnectionError, Timeout
 from unidecode import unidecode
 
+from backend.media_client import BaseMediaClient
 from backend.models import PlexClientInfo, PlexPlaylistInfo, Track
 
 logger = logging.getLogger(__name__)
@@ -162,7 +163,7 @@ def is_live_version(track: Any) -> bool:
     return False
 
 
-class PlexClient:
+class PlexClient(BaseMediaClient):
     """Client for interacting with Plex server."""
 
     # Cooldown between reconnection attempts (seconds)
@@ -636,6 +637,14 @@ class PlexClient:
             )
         except Exception:
             return None
+
+    def get_art_url(self, item_id: str) -> str | None:
+        """Get the proxied art URL for a track/album item.
+
+        Returns the Plex thumb path (relative) which main.py will proxy with auth.
+        We return the thumb path here; main.py appends the base URL and token.
+        """
+        return self.get_thumb_path(item_id)
 
     def create_playlist(
         self, name: str, rating_keys: list[str], description: str = ""

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,11 @@
 # Copy this file to config.yaml and update with your settings
 # Environment variables take priority over values in this file
 
+# Media server selection: "plex" or "jellyfin"
+# Override with MEDIA_SERVER env var
+# Auto-detected: if JELLYFIN_URL is set and PLEX_URL is not, defaults to "jellyfin"
+media_server: "plex"
+
 plex:
   # Plex server URL (override with PLEX_URL env var)
   url: "http://your-plex-server:32400"
@@ -9,6 +14,15 @@ plex:
   # See: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
   token: ""
   # Name of your music library section in Plex
+  music_library: "Music"
+
+jellyfin:
+  # Jellyfin server URL (override with JELLYFIN_URL env var)
+  url: ""
+  # Jellyfin API key — create one in Jellyfin: Dashboard > API Keys
+  # Override with JELLYFIN_TOKEN env var
+  token: ""
+  # Name of your music library in Jellyfin
   music_library: "Music"
 
 llm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,19 @@ services:
     ports:
       - "5765:5765"
     environment:
-      # Required: Plex server settings
-      - PLEX_URL=${PLEX_URL}
-      - PLEX_TOKEN=${PLEX_TOKEN}
+      # Media server selection: "plex" or "jellyfin" (auto-detected if only one URL is set)
+      #- MEDIA_SERVER=plex
+
+      # Plex server settings (use if MEDIA_SERVER=plex)
+      - PLEX_URL=${PLEX_URL:-}
+      - PLEX_TOKEN=${PLEX_TOKEN:-}
       - PLEX_MUSIC_LIBRARY=${PLEX_MUSIC_LIBRARY:-Music}
+
+      # Jellyfin server settings (use if MEDIA_SERVER=jellyfin)
+      # API key: create in Jellyfin Dashboard > API Keys
+      - JELLYFIN_URL=${JELLYFIN_URL:-}
+      - JELLYFIN_TOKEN=${JELLYFIN_TOKEN:-}
+      - JELLYFIN_MUSIC_LIBRARY=${JELLYFIN_MUSIC_LIBRARY:-Music}
 
       # Performance tuning
       - UVICORN_WORKERS=${UVICORN_WORKERS:-1}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -279,6 +279,13 @@ async function validatePlex(url, token, library) {
     });
 }
 
+async function validateJellyfin(url, token, library) {
+    return apiCall('/setup/validate-jellyfin', {
+        method: 'POST',
+        body: JSON.stringify({ jellyfin_url: url, jellyfin_token: token, music_library: library }),
+    });
+}
+
 async function validateAI(provider, apiKey, ollamaUrl, customUrl) {
     return apiCall('/setup/validate-ai', {
         method: 'POST',
@@ -1196,12 +1203,19 @@ function updateFilters() {
     // Update checkboxes
     document.getElementById('exclude-live').checked = state.excludeLive;
 
-    // Update rating buttons
-    document.querySelectorAll('.rating-btn').forEach(btn => {
-        const isActive = parseInt(btn.dataset.rating) === state.minRating;
-        btn.classList.toggle('active', isActive);
-        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    });
+    // Update rating buttons — hide entirely for Jellyfin (no rating support)
+    const ratingSection = document.getElementById('filter-rating-section');
+    const isJellyfin = state.config?.media_server === 'jellyfin';
+    if (ratingSection) ratingSection.classList.toggle('hidden', isJellyfin);
+    if (isJellyfin) {
+        state.minRating = 0;
+    } else {
+        document.querySelectorAll('.rating-btn').forEach(btn => {
+            const isActive = parseInt(btn.dataset.rating) === state.minRating;
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    }
 }
 
 function updateModelSuggestion() {
@@ -1713,9 +1727,30 @@ function updateResultsFooter() {
 function updateSettings() {
     if (!state.config) return;
 
+    // Media server selector
+    const mediaServerSelect = document.getElementById('settings-media-server');
+    if (mediaServerSelect) {
+        mediaServerSelect.value = state.config.media_server || 'plex';
+        _showMediaServerFields(state.config.media_server || 'plex');
+    }
+
     document.getElementById('plex-url').value = state.config.plex_url || '';
-    document.getElementById('music-library').value = state.config.music_library || 'Music';
+    document.getElementById('music-library').value = state.config.media_server === 'jellyfin'
+        ? (state.config.jellyfin_music_library || 'Music')
+        : (state.config.music_library || 'Music');
     document.getElementById('llm-provider').value = state.config.llm_provider || 'gemini';
+
+    // Jellyfin fields
+    const jellyfinUrl = document.getElementById('jellyfin-url');
+    if (jellyfinUrl) jellyfinUrl.value = state.config.jellyfin_url || '';
+    const jellyfinLib = document.getElementById('jellyfin-music-library');
+    if (jellyfinLib) jellyfinLib.value = state.config.jellyfin_music_library || 'Music';
+    const jellyfinToken = document.getElementById('jellyfin-token');
+    if (jellyfinToken) {
+        jellyfinToken.placeholder = state.config.jellyfin_token_set
+            ? '•••••••••••••••• (configured)'
+            : 'Your Jellyfin API key';
+    }
 
     // Show warning if provider is set by environment variable
     const providerEnvWarning = document.getElementById('provider-env-warning');
@@ -1753,17 +1788,55 @@ function updateSettings() {
 
     // Update status indicators
     const plexStatus = document.getElementById('plex-status');
-    plexStatus.classList.toggle('connected', state.config.plex_connected);
-    plexStatus.querySelector('.status-text').textContent =
-        state.config.plex_connected ? 'Connected' : 'Not connected';
+    if (plexStatus) {
+        plexStatus.classList.toggle('connected', state.config.plex_connected);
+        plexStatus.querySelector('.status-text').textContent =
+            state.config.plex_connected ? 'Connected' : 'Not connected';
+    }
+
+    const jellyfinStatus = document.getElementById('jellyfin-status');
+    if (jellyfinStatus) {
+        const jellyfinConnected = !!(state.config.jellyfin_url && state.config.jellyfin_token_set);
+        jellyfinStatus.classList.toggle('connected', jellyfinConnected);
+        jellyfinStatus.querySelector('.status-text').textContent =
+            jellyfinConnected ? 'Connected' : 'Not connected';
+    }
 
     const llmStatus = document.getElementById('llm-status');
-    llmStatus.classList.toggle('connected', state.config.llm_configured);
-    llmStatus.querySelector('.status-text').textContent =
-        state.config.llm_configured ? 'Configured' : 'Not configured';
+    if (llmStatus) {
+        llmStatus.classList.toggle('connected', state.config.llm_configured);
+        llmStatus.querySelector('.status-text').textContent =
+            state.config.llm_configured ? 'Configured' : 'Not configured';
+    }
+
+    // Update Save button label
+    const saveLabelLong = document.getElementById('save-playlist-btn-label');
+    if (saveLabelLong) {
+        saveLabelLong.textContent = state.config.media_server === 'jellyfin' ? 'Save to Jellyfin' : 'Save to Plex';
+    }
+
+    // Show/hide Play Now button (Plex-only feature)
+    const playNowBtn = document.getElementById('play-now-btn');
+    if (playNowBtn) {
+        playNowBtn.style.display = state.config.media_server === 'jellyfin' ? 'none' : '';
+    }
 
     // Show provider-specific settings
     showProviderSettings(state.config.llm_provider);
+}
+
+function _showMediaServerFields(server) {
+    const plexFields = document.getElementById('settings-plex-fields');
+    const jellyfinFields = document.getElementById('settings-jellyfin-fields');
+    if (plexFields) plexFields.classList.toggle('hidden', server === 'jellyfin');
+    if (jellyfinFields) jellyfinFields.classList.toggle('hidden', server !== 'jellyfin');
+}
+
+function _updateSetupServerFields(server) {
+    const plexFields = document.getElementById('setup-plex-fields');
+    const jellyfinFields = document.getElementById('setup-jellyfin-fields');
+    if (plexFields) plexFields.classList.toggle('hidden', server === 'jellyfin');
+    if (jellyfinFields) jellyfinFields.classList.toggle('hidden', server !== 'jellyfin');
 }
 
 function showProviderSettings(provider) {
@@ -1990,7 +2063,10 @@ function validateCustomContextInline() {
 }
 
 function updateConfigRequiredUI() {
-    const plexConnected = state.config?.plex_connected ?? false;
+    const mediaServer = state.config?.media_server || 'plex';
+    const serverConnected = mediaServer === 'jellyfin'
+        ? !!(state.config?.jellyfin_url && state.config?.jellyfin_token_set)
+        : (state.config?.plex_connected ?? false);
     const llmConfigured = state.config?.llm_configured ?? false;
 
     // Elements that require configuration
@@ -2006,23 +2082,24 @@ function updateConfigRequiredUI() {
     const hintSeed = document.getElementById('llm-required-hint-seed');
 
     // Determine what's missing
-    const needsPlex = !plexConnected;
+    const needsServer = !serverConnected;
     const needsLLM = !llmConfigured;
-    const needsConfig = needsPlex || needsLLM;
+    const needsConfig = needsServer || needsLLM;
 
     // Update button/input states
     if (analyzeBtn) analyzeBtn.disabled = needsConfig;
     if (continueBtn) continueBtn.disabled = needsLLM; // Only needs LLM at this point
-    if (searchBtn) searchBtn.disabled = needsPlex;
-    if (searchInput) searchInput.disabled = needsPlex;
-    if (promptTextarea) promptTextarea.disabled = needsPlex;
+    if (searchBtn) searchBtn.disabled = needsServer;
+    if (searchInput) searchInput.disabled = needsServer;
+    if (promptTextarea) promptTextarea.disabled = needsServer;
 
     // Build hint message based on what's missing
+    const serverLabel = mediaServer === 'jellyfin' ? 'Jellyfin' : 'Plex';
     let hintMessage = '';
-    if (needsPlex && needsLLM) {
-        hintMessage = '<a href="#" data-view="settings">Configure Plex and an LLM provider</a> to continue';
-    } else if (needsPlex) {
-        hintMessage = '<a href="#" data-view="settings">Connect to Plex</a> to continue';
+    if (needsServer && needsLLM) {
+        hintMessage = `<a href="#" data-view="settings">Configure ${serverLabel} and an LLM provider</a> to continue`;
+    } else if (needsServer) {
+        hintMessage = `<a href="#" data-view="settings">Connect to ${serverLabel}</a> to continue`;
     } else if (needsLLM) {
         hintMessage = '<a href="#" data-view="settings">Configure an LLM provider</a> to continue';
     }
@@ -2262,7 +2339,7 @@ function updateSyncProgress(phase, current, total) {
     } else if (phase === 'fetching') {
         // Indeterminate state - fetching tracks from Plex
         fill.style.width = '0%';
-        text.textContent = 'Fetching tracks from Plex...';
+        text.textContent = 'Fetching tracks from library...';
         if (bar) bar.setAttribute('aria-valuenow', '0');
     } else if (phase === 'processing') {
         // Processing phase - show progress
@@ -2709,6 +2786,14 @@ function setupEventListeners() {
     // Success modal - Start New Playlist
     document.getElementById('new-playlist-btn').addEventListener('click', hideSuccessModal);
 
+    // Media server selection change
+    const mediaServerSelect = document.getElementById('settings-media-server');
+    if (mediaServerSelect) {
+        mediaServerSelect.addEventListener('change', (e) => {
+            _showMediaServerFields(e.target.value);
+        });
+    }
+
     // Provider selection change
     document.getElementById('llm-provider').addEventListener('change', (e) => {
         showProviderSettings(e.target.value);
@@ -2930,8 +3015,12 @@ function renderSearchResults(tracks) {
 
 async function selectSeedTrack(ratingKey, tracks) {
     // Check if services are configured before proceeding
-    if (!state.config?.plex_connected) {
-        showError('Connect to Plex in Settings first');
+    const _isServerConnected = state.config?.media_server === 'jellyfin'
+        ? !!(state.config?.jellyfin_url && state.config?.jellyfin_token_set)
+        : state.config?.plex_connected;
+    if (!_isServerConnected) {
+        const _label = state.config?.media_server === 'jellyfin' ? 'Jellyfin' : 'Plex';
+        showError(`Connect to ${_label} in Settings first`);
         return;
     }
     if (!state.config?.llm_configured) {
@@ -3177,12 +3266,13 @@ async function handleSavePlaylist() {
         return;
     }
 
+    const _serverLabel = state.config?.media_server === 'jellyfin' ? 'Jellyfin' : 'Plex';
     const saveSteps = [
-        'Connecting to Plex server...',
+        `Connecting to ${_serverLabel} server...`,
         'Creating playlist...',
         'Adding tracks...',
     ];
-    setLoading(true, 'Saving to Plex...', saveSteps);
+    setLoading(true, `Saving to ${_serverLabel}...`, saveSteps);
 
     try {
         const ratingKeys = state.playlist.map(t => t.rating_key);
@@ -3221,17 +3311,21 @@ async function loadSettings() {
         updateFooter();
         updateConfigRequiredUI();
 
-        // Show library stats if connected
-        if (state.config.plex_connected) {
+        // Show library stats if connected (Plex or Jellyfin)
+        const isMediaConnected = state.config.media_server === 'jellyfin'
+            ? !!(state.config.jellyfin_url && state.config.jellyfin_token_set)
+            : state.config.plex_connected;
+        if (isMediaConnected) {
             const statsSection = document.getElementById('library-stats-section');
-            statsSection.style.display = 'block';
+            if (statsSection) statsSection.style.display = 'block';
 
             try {
                 const stats = await fetchLibraryStats();
                 // Cache genre/decade data so other views don't need a separate fetch
                 state.availableGenres = stats.genres;
                 state.availableDecades = stats.decades;
-                document.getElementById('library-stats').innerHTML = `
+                const statsEl = document.getElementById('library-stats');
+                if (statsEl) statsEl.innerHTML = `
                     <p><strong>Total Tracks:</strong> ${stats.total_tracks.toLocaleString()}</p>
                     <p><strong>Genres:</strong> ${stats.genres.length}</p>
                     <p><strong>Decades:</strong> ${stats.decades.map(d => d.name).join(', ')}</p>
@@ -3248,9 +3342,13 @@ async function loadSettings() {
 async function handleSaveSettings() {
     const updates = {};
 
+    const mediaServer = document.getElementById('settings-media-server')?.value || 'plex';
     const plexUrl = document.getElementById('plex-url').value.trim();
     const plexToken = document.getElementById('plex-token').value.trim();
     const musicLibrary = document.getElementById('music-library').value.trim();
+    const jellyfinUrl = document.getElementById('jellyfin-url')?.value.trim() || '';
+    const jellyfinToken = document.getElementById('jellyfin-token')?.value.trim() || '';
+    const jellyfinMusicLibrary = document.getElementById('jellyfin-music-library')?.value.trim() || 'Music';
     const llmProvider = document.getElementById('llm-provider').value;
     const llmApiKey = document.getElementById('llm-api-key').value.trim();
 
@@ -3265,9 +3363,13 @@ async function handleSaveSettings() {
     const customModel = document.getElementById('custom-model').value.trim();
     const customContextWindow = parseInt(document.getElementById('custom-context-window').value) || 32768;
 
+    if (mediaServer) updates.media_server = mediaServer;
     if (plexUrl) updates.plex_url = plexUrl;
     if (plexToken) updates.plex_token = plexToken;
-    if (musicLibrary) updates.music_library = musicLibrary;
+    if (musicLibrary && mediaServer !== 'jellyfin') updates.music_library = musicLibrary;
+    if (jellyfinUrl) updates.jellyfin_url = jellyfinUrl;
+    if (jellyfinToken) updates.jellyfin_token = jellyfinToken;
+    if (jellyfinMusicLibrary) updates.jellyfin_music_library = jellyfinMusicLibrary;
     if (llmProvider) updates.llm_provider = llmProvider;
 
     // Set provider-specific settings
@@ -3312,10 +3414,15 @@ async function handleSaveSettings() {
 
         // Clear password fields after save
         document.getElementById('plex-token').value = '';
+        const jellyfinTokenEl = document.getElementById('jellyfin-token');
+        if (jellyfinTokenEl) jellyfinTokenEl.value = '';
         document.getElementById('llm-api-key').value = '';
 
         // Reload library stats
-        if (state.config.plex_connected) {
+        const isConnectedAfterSave = state.config.media_server === 'jellyfin'
+            ? !!(state.config.jellyfin_url && state.config.jellyfin_token_set)
+            : state.config.plex_connected;
+        if (isConnectedAfterSave) {
             loadSettings();
         }
     } catch (error) {
@@ -3612,7 +3719,8 @@ function setSaveMode(mode) {
     const pickerContainer = document.getElementById('playlist-picker-container');
 
     if (mode === 'new') {
-        saveBtn.innerHTML = '<span class="btn-label-long">Save to Plex</span><span class="btn-label-short">Save</span>';
+        const _saveLabel = state.config?.media_server === 'jellyfin' ? 'Jellyfin' : 'Plex';
+        saveBtn.innerHTML = `<span class="btn-label-long">Save to ${_saveLabel}</span><span class="btn-label-short">Save</span>`;
         nameContainer.classList.remove('hidden');
         pickerContainer.classList.add('hidden');
     } else if (mode === 'replace') {
@@ -5078,7 +5186,10 @@ function exitSetupWizard() {
 
     // Run normal init
     loadSettings().then(() => {
-        if (state.config?.plex_connected) checkLibraryStatus();
+        const isConnected = state.config?.media_server === 'jellyfin'
+            ? !!(state.config?.jellyfin_url && state.config?.jellyfin_token_set)
+            : state.config?.plex_connected;
+        if (isConnected) checkLibraryStatus();
     }).catch(() => {});
     renderHistoryFeed();
 }
@@ -5094,15 +5205,21 @@ function renderSetupState(status) {
         dataWarning.classList.add('hidden');
     }
 
-    // Step 1: Plex
-    if (status.plex_connected) {
-        setStepDone('plex', `Connected to Plex (${status.music_libraries.length} music ${status.music_libraries.length === 1 ? 'library' : 'libraries'})`);
+    // Step 1: Media Server
+    const isServerConnected = status.media_server === 'jellyfin'
+        ? status.jellyfin_connected
+        : status.plex_connected;
+    if (isServerConnected) {
+        const serverLabel = status.media_server === 'jellyfin' ? 'Jellyfin' : 'Plex';
+        setStepDone('plex', `Connected to ${serverLabel} (${status.music_libraries.length} music ${status.music_libraries.length === 1 ? 'library' : 'libraries'})`);
     } else {
         setStepForm('plex');
-        if (status.plex_from_env) {
-            const urlInput = document.getElementById('setup-plex-url');
-            if (urlInput && !urlInput.value) urlInput.value = '';
-        }
+        // Pre-select server type if known from env
+        const radioButtons = document.querySelectorAll('input[name="setup-media-server"]');
+        radioButtons.forEach(r => {
+            r.checked = r.value === (status.media_server || 'plex');
+        });
+        _updateSetupServerFields(status.media_server || 'plex');
     }
 
     // Step 2: AI
@@ -5122,7 +5239,7 @@ function renderSetupState(status) {
     } else if (status.is_syncing) {
         showSyncProgress(status);
         startSetupSyncPolling();
-    } else if (status.plex_connected && status.llm_configured) {
+    } else if (isServerConnected && status.llm_configured) {
         // Auto-trigger sync
         triggerSetupSync();
     } else {
@@ -5132,7 +5249,7 @@ function renderSetupState(status) {
     }
 
     // Step 4: Get Started
-    const allDone = status.plex_connected && status.llm_configured &&
+    const allDone = isServerConnected && status.llm_configured &&
         status.library_synced && !status.is_syncing;
     const getStartedBtn = document.getElementById('setup-get-started-btn');
     getStartedBtn.disabled = !allDone;
@@ -5258,37 +5375,69 @@ function setupWizardEventListeners() {
     if (_setupListenersAttached) return;
     _setupListenersAttached = true;
 
-    // Plex validation
-    document.getElementById('setup-plex-btn').addEventListener('click', async () => {
-        const url = document.getElementById('setup-plex-url').value.trim();
-        const token = document.getElementById('setup-plex-token').value.trim();
-        const library = document.getElementById('setup-plex-library').value.trim() || 'Music';
+    // Media server radio buttons — show/hide fields
+    document.querySelectorAll('input[name="setup-media-server"]').forEach(radio => {
+        radio.addEventListener('change', () => {
+            _updateSetupServerFields(radio.value);
+        });
+    });
 
-        if (!url || !token) {
-            setStepError('plex', 'URL and token are required');
-            return;
-        }
+    // Media server connect button — routes to Plex or Jellyfin based on radio selection
+    document.getElementById('setup-plex-btn').addEventListener('click', async () => {
+        const selectedServer = document.querySelector('input[name="setup-media-server"]:checked')?.value || 'plex';
+        const btn = document.getElementById('setup-plex-btn');
 
         clearStepError('plex');
-        const btn = document.getElementById('setup-plex-btn');
         btn.disabled = true;
         btn.textContent = 'Connecting...';
 
         try {
-            const result = await validatePlex(url, token, library);
+            let result;
+            if (selectedServer === 'jellyfin') {
+                const url = document.getElementById('setup-jellyfin-url')?.value.trim() || '';
+                const token = document.getElementById('setup-jellyfin-token')?.value.trim() || '';
+                const library = document.getElementById('setup-jellyfin-library')?.value.trim() || 'Music';
+                if (!url || !token) {
+                    setStepError('plex', 'URL and API key are required');
+                    return;
+                }
+                result = await validateJellyfin(url, token, library);
+                if (result.success) {
+                    state.setup.status.jellyfin_connected = true;
+                    state.setup.status.media_server = 'jellyfin';
+                    state.setup.status.music_libraries = result.music_libraries || [];
+                    setStepDone('plex', result.server_name
+                        ? `Connected to ${result.server_name}` : 'Connected to Jellyfin');
+                } else {
+                    setStepError('plex', result.error || 'Connection failed');
+                }
+            } else {
+                const url = document.getElementById('setup-plex-url').value.trim();
+                const token = document.getElementById('setup-plex-token').value.trim();
+                const library = document.getElementById('setup-plex-library').value.trim() || 'Music';
+                if (!url || !token) {
+                    setStepError('plex', 'URL and token are required');
+                    return;
+                }
+                result = await validatePlex(url, token, library);
+                if (result.success) {
+                    state.setup.status.plex_connected = true;
+                    state.setup.status.media_server = 'plex';
+                    state.setup.status.music_libraries = result.music_libraries || [];
+                    setStepDone('plex', result.server_name
+                        ? `Connected to ${result.server_name}` : 'Connected to Plex');
+                } else {
+                    setStepError('plex', result.error || 'Connection failed');
+                }
+            }
+
             if (result.success) {
-                state.setup.status.plex_connected = true;
-                state.setup.status.music_libraries = result.music_libraries || [];
-                setStepDone('plex', result.server_name
-                    ? `Connected to ${result.server_name}` : 'Connected to Plex');
                 // Auto-trigger sync if AI is also done
                 if (state.setup.status.llm_configured && !state.setup.status.library_synced) {
                     state.setup.status.is_syncing = true;
                     triggerSetupSync();
                 }
                 renderSetupState(state.setup.status);
-            } else {
-                setStepError('plex', result.error || 'Connection failed');
             }
         } catch (e) {
             setStepError('plex', e.message);
@@ -5340,8 +5489,11 @@ function setupWizardEventListeners() {
                 state.setup.status.llm_configured = true;
                 state.setup.status.llm_provider = provider;
                 setStepDone('ai', `Using ${result.provider_name || provider}`);
-                // Auto-trigger sync if Plex is also done
-                if (state.setup.status.plex_connected && !state.setup.status.library_synced) {
+                // Auto-trigger sync if media server is also done
+                const serverConnected = state.setup.status.media_server === 'jellyfin'
+                    ? state.setup.status.jellyfin_connected
+                    : state.setup.status.plex_connected;
+                if (serverConnected && !state.setup.status.library_synced) {
                     state.setup.status.is_syncing = true;
                     triggerSetupSync();
                 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -60,29 +60,62 @@
                         </div>
                     </div>
 
-                    <!-- Step 1: Plex -->
+                    <!-- Step 1: Media Server -->
                     <div class="setup-step" id="setup-step-plex">
                         <div class="setup-step-header">
                             <span class="setup-step-number">1</span>
                             <div class="setup-step-title">
-                                <h3>Connect to Plex</h3>
+                                <h3>Connect to Media Server</h3>
                                 <span class="setup-step-status" id="setup-plex-status"></span>
                             </div>
                         </div>
                         <div class="setup-step-body" id="setup-plex-body">
                             <div class="setup-step-form" id="setup-plex-form">
+                                <!-- Media server selector -->
                                 <div class="form-group">
-                                    <label for="setup-plex-url">Plex Server URL</label>
-                                    <input type="text" id="setup-plex-url" placeholder="http://your-plex-server:32400">
+                                    <label>Media Server</label>
+                                    <div class="media-server-selector">
+                                        <label class="media-server-option">
+                                            <input type="radio" name="setup-media-server" value="plex" checked>
+                                            <span>Plex</span>
+                                        </label>
+                                        <label class="media-server-option">
+                                            <input type="radio" name="setup-media-server" value="jellyfin">
+                                            <span>Jellyfin</span>
+                                        </label>
+                                    </div>
                                 </div>
-                                <div class="form-group">
-                                    <label for="setup-plex-token">Plex Token</label>
-                                    <input type="password" id="setup-plex-token" placeholder="Your Plex token">
-                                    <p class="setup-field-hint">Find your token: <a href="https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/" target="_blank" rel="noopener">Plex support article</a></p>
+                                <!-- Plex fields -->
+                                <div id="setup-plex-fields">
+                                    <div class="form-group">
+                                        <label for="setup-plex-url">Plex Server URL</label>
+                                        <input type="text" id="setup-plex-url" placeholder="http://your-plex-server:32400">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="setup-plex-token">Plex Token</label>
+                                        <input type="password" id="setup-plex-token" placeholder="Your Plex token">
+                                        <p class="setup-field-hint">Find your token: <a href="https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/" target="_blank" rel="noopener">Plex support article</a></p>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="setup-plex-library">Music Library</label>
+                                        <input type="text" id="setup-plex-library" value="Music" placeholder="Music library name">
+                                    </div>
                                 </div>
-                                <div class="form-group">
-                                    <label for="setup-plex-library">Music Library</label>
-                                    <input type="text" id="setup-plex-library" value="Music" placeholder="Music library name">
+                                <!-- Jellyfin fields -->
+                                <div id="setup-jellyfin-fields" class="hidden">
+                                    <div class="form-group">
+                                        <label for="setup-jellyfin-url">Jellyfin Server URL</label>
+                                        <input type="text" id="setup-jellyfin-url" placeholder="http://your-jellyfin-server:8096">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="setup-jellyfin-token">API Key</label>
+                                        <input type="password" id="setup-jellyfin-token" placeholder="Your Jellyfin API key">
+                                        <p class="setup-field-hint">Create an API key in Jellyfin: Dashboard &rarr; Advanced &rarr; API Keys</p>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="setup-jellyfin-library">Music Library</label>
+                                        <input type="text" id="setup-jellyfin-library" value="Music" placeholder="Music library name">
+                                    </div>
                                 </div>
                                 <div id="setup-plex-error" class="setup-inline-error hidden" role="alert"></div>
                                 <button id="setup-plex-btn" class="btn btn-primary">Connect</button>
@@ -367,7 +400,7 @@
                             </label>
                         </div>
 
-                        <div class="filter-section">
+                        <div class="filter-section" id="filter-rating-section">
                             <h3>Minimum Rating</h3>
                             <div class="rating-selector" role="group" aria-label="Minimum track rating">
                                 <button class="rating-btn active" data-rating="0" aria-pressed="true">Any</button>
@@ -431,7 +464,7 @@
                                 <div class="results-header-actions">
                                     <div class="split-button-group">
                                         <button id="save-playlist-btn" class="btn btn-primary split-button-main">
-                                            <span class="btn-label-long">Save to Plex</span><span class="btn-label-short">Save</span>
+                                            <span class="btn-label-long" id="save-playlist-btn-label">Save to Library</span><span class="btn-label-short">Save</span>
                                         </button>
                                         <button id="save-mode-dropdown-btn" class="btn btn-primary split-button-arrow" aria-label="Save mode options" aria-expanded="false">
                                             <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M3 5L6 8L9 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
@@ -640,22 +673,52 @@
                 <h2>Settings</h2>
 
                 <section class="settings-section">
-                    <h3>Plex Connection</h3>
-                    <div class="status-indicator" id="plex-status">
-                        <span class="status-dot"></span>
-                        <span class="status-text">Not connected</span>
-                    </div>
+                    <h3>Media Server</h3>
                     <div class="form-group">
-                        <label for="plex-url">Plex Server URL</label>
-                        <input type="text" id="plex-url" placeholder="http://your-plex-server:32400">
+                        <label for="settings-media-server">Server Type</label>
+                        <select id="settings-media-server">
+                            <option value="plex">Plex</option>
+                            <option value="jellyfin">Jellyfin</option>
+                        </select>
                     </div>
-                    <div class="form-group">
-                        <label for="plex-token">Plex Token</label>
-                        <input type="password" id="plex-token" placeholder="Your Plex token">
+                    <!-- Plex settings -->
+                    <div id="settings-plex-fields">
+                        <div class="status-indicator" id="plex-status">
+                            <span class="status-dot"></span>
+                            <span class="status-text">Not connected</span>
+                        </div>
+                        <div class="form-group">
+                            <label for="plex-url">Plex Server URL</label>
+                            <input type="text" id="plex-url" placeholder="http://your-plex-server:32400">
+                        </div>
+                        <div class="form-group">
+                            <label for="plex-token">Plex Token</label>
+                            <input type="password" id="plex-token" placeholder="Your Plex token">
+                        </div>
+                        <div class="form-group">
+                            <label for="music-library">Music Library</label>
+                            <input type="text" id="music-library" value="Music" placeholder="Music library name">
+                        </div>
                     </div>
-                    <div class="form-group">
-                        <label for="music-library">Music Library</label>
-                        <input type="text" id="music-library" value="Music" placeholder="Music library name">
+                    <!-- Jellyfin settings -->
+                    <div id="settings-jellyfin-fields" class="hidden">
+                        <div class="status-indicator" id="jellyfin-status">
+                            <span class="status-dot"></span>
+                            <span class="status-text">Not connected</span>
+                        </div>
+                        <div class="form-group">
+                            <label for="jellyfin-url">Jellyfin Server URL</label>
+                            <input type="text" id="jellyfin-url" placeholder="http://your-jellyfin-server:8096">
+                        </div>
+                        <div class="form-group">
+                            <label for="jellyfin-token">API Key</label>
+                            <input type="password" id="jellyfin-token" placeholder="Your Jellyfin API key">
+                            <p class="setup-field-hint">Create an API key in Jellyfin: Dashboard &rarr; Advanced &rarr; API Keys</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="jellyfin-music-library">Music Library</label>
+                            <input type="text" id="jellyfin-music-library" value="Music" placeholder="Music library name">
+                        </div>
                     </div>
                 </section>
 


### PR DESCRIPTION
## Add Jellyfin support as an alternative media server

Closes #11

### Backend
- Introduced a `BaseMediaClient` abstract class to provide a common interface for both Plex and Jellyfin clients
- Added a full `JellyfinClient` implementation (REST API via `httpx`) covering tracks, playlists, library stats, art proxying, and filters
- `PlexClient` now extends `BaseMediaClient`
- Config loading, models, and API routes updated to support a `media_server` setting (`"plex"` or `"jellyfin"`), with auto-detection if only one server URL is set

### Frontend
- Setup wizard and settings panel updated with a Plex/Jellyfin selector and server-specific input fields
- UI elements (save button label, rating filter, Play Now button) now adapt dynamically based on the active media server

### Config & Infrastructure
- `.env.example`, `config.example.yaml`, and `docker-compose.yml` updated with Jellyfin environment variables (`JELLYFIN_URL`, `JELLYFIN_TOKEN`, `JELLYFIN_MUSIC_LIBRARY`)