### PR TITLE
Update plex_client.py

### DIFF
--- a/backend/plex_client.py
+++ b/backend/plex_client.py
@@ -749,11 +749,11 @@ class PlexClient:
             seen_ids.add(mid)
             result.append(PlexClientInfo(
                 client_id=mid,
-                name=client.title,
-                product=client.product,
-                platform=client.platform,
+                name=client.title or "unknown",
+                product=client.product or "unknown",
+                platform=client.platform or "unknown",
                 is_playing=is_playing,
-                is_mobile=self._is_mobile_client(client.product, client.platform),
+                is_mobile=self._is_mobile_client(client.product or "unknown", client.platform or "unknown"),
             ))
 
         local_count = len(result)


### PR DESCRIPTION
When a Plex client (e.g. headless Plexamp on Raspberry Pi) returns None for the platform field, Pydantic raises a ValidationError when constructing PlexClientInfo. This causes the entire get_clients call to fail, so no devices are returned at all — including clients that do have valid metadata. The UI shows "Failed to find devices" even when Plex is healthy and other clients are active. Fix: add or "unknown" fallback to name, product, and platform fields, and to the _is_mobile_client() call, so that clients with missing metadata are handled gracefully instead of crashing the whole list. Tested and confirmed working with a mixed setup of a macOS Plexamp client and a headless Raspberry Pi Plexamp speaker on Unraid with Plex in host network mode.